### PR TITLE
maxchars

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ then, the doc has 3 fields like this.
 | columns  | Define a list of column names. | Yes |
 | quote_char | Define the character used to quote CSV fields. If this is not specified the default is a double quote ". | No |
 | separator | Define the column separator value. If this is not specified, the default is a comma ,. | No |
+| max_chars_per_column | Define the maximum amount of chars a column can have in it, before the plugin gives up.  This is set to limit the amount of memory consumed. Valid values are 2 - 64000. Default is 4096 | No |
+
 
 ## Setup
 

--- a/src/test/java/info/johtani/elasticsearch/plugin/ingest/csv/CsvProcessorFactoryTests.java
+++ b/src/test/java/info/johtani/elasticsearch/plugin/ingest/csv/CsvProcessorFactoryTests.java
@@ -113,5 +113,22 @@ public class CsvProcessorFactoryTests extends ESTestCase {
             () -> factory.create(null, processorTag, configEmpty));
         assertThat(e.getMessage(), equalTo("columns is missing"));
     }
+    public void testMaxChars() throws Exception {
+        Map<String, Object> config = getDefaultConfig();
+        config.put("max_chars_per_column", 65000);
+        String processorTag = randomAlphaOfLength(10);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> factory.create(null, processorTag, config));
+        assertThat(e.getMessage(), equalTo("maxCharsPerColumn must be between 1 and 64000 (default 4096)"));
+
+        final Map<String, Object> configinvalid = getDefaultConfig();
+        configinvalid.put("max_chars_per_column", 0);
+
+        IllegalArgumentException epe = expectThrows(IllegalArgumentException.class,
+            () -> factory.create(null, processorTag, configinvalid));
+        assertThat(e.getMessage(), equalTo("maxCharsPerColumn must be between 1 and 64000 (default 4096)"));
+    }
+
 
 }

--- a/src/test/java/info/johtani/elasticsearch/plugin/ingest/csv/CsvProcessorTests.java
+++ b/src/test/java/info/johtani/elasticsearch/plugin/ingest/csv/CsvProcessorTests.java
@@ -47,7 +47,7 @@ public class CsvProcessorTests extends ESTestCase {
         document.put("source_field", "a_value, b_value");
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
 
-        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',');
+        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',',4096);
         Map<String, Object> data = processor.execute(ingestDocument).getSourceAndMetadata();
 
         assertThat(data, hasKey("a"));
@@ -62,7 +62,7 @@ public class CsvProcessorTests extends ESTestCase {
         documentShort.put("source_field", "a_value");
         IngestDocument ingestDocumentShort = RandomDocumentPicks.randomIngestDocument(random(), documentShort);
 
-        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',');
+        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',',4096);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocumentShort));
         assertThat(e.getMessage(), equalTo("field[source_field] size [1] doesn't match header size [" + defaultColumns.size() + "]."));
@@ -80,14 +80,14 @@ public class CsvProcessorTests extends ESTestCase {
         document.put("source_field", "");
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
 
-        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',');
+        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',',4096);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
         assertThat(e.getMessage(), equalTo("field[source_field] is empty string."));
     }
 
     public void testManyTimes() throws Exception {
-        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',');
+        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(10), "source_field", defaultColumns, '\"', ',',4096);
         int times = 50000;
 
         logger.info("start");


### PR DESCRIPTION
I've added in support to set the max chars feature, which is passed to the underlying com.univocity.parsers.csv.CsvParser parser. This allows it to be set to more than 4096 bytes, if a column is longer than that. The default is left at 4096.

http://javadox.com/com.univocity/univocity-parsers/2.0.0/com/univocity/parsers/common/CommonSettings.html#setMaxCharsPerColumn(int)

This seems to work OK for us.